### PR TITLE
Change orderHistory to pull by customer_id

### DIFF
--- a/lib/customers.js
+++ b/lib/customers.js
@@ -18,8 +18,8 @@ module.exports = function (restClient) {
     module.orderHistory = function (requestToken) {
         
         return restClient.get('/customers/me', requestToken).then((result) => {
-            var query = 'searchCriteria=&searchCriteria[filterGroups][0][filters][0][field]=customer_email&' +
-            'searchCriteria[filterGroups][0][filters][0][value]=' + encodeURIComponent(result.email) + '&' +
+            var query = 'searchCriteria=&searchCriteria[filterGroups][0][filters][0][field]=customer_id&' +
+            'searchCriteria[filterGroups][0][filters][0][value]=' + result.id + '&' +
             'searchCriteria[filterGroups][0][filters][0][condition_type]=eq&searchCriteria[pageSize]=20&' +
             'searchCriteria[sortOrders][0][field]=entity_id&searchCriteria[sortOrders][0][direction]=desc';
             var endpointUrl = util.format('/orders?%s', query);


### PR DESCRIPTION
Closes #8 

Change the orderHistory API to filter by `customer_id` so that the history is unique per customer and retains all orders even if the customer changes their email.