### PR TITLE
add Credit for original Author to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,6 @@ Magento API with Swagger: https://devdocs.magento.com/swagger/
 Entry Page of REST API Documentation of Magento: https://devdocs.magento.com/guides/v2.3/rest/bk-rest.html
 filter response: https://devdocs.magento.com/guides/v2.3/rest/retrieve-filtered-responses.html
 
+## Credit
+
+This Repository is an independent fork of https://github.com/nouvak/magento2-rest-client created by Marko Novak.


### PR DESCRIPTION
While the Author is already Credited in the License File, (and partially in the package.json) I believe its good practice to also mention the Repository and Author as part of the Readme File.