### PR TITLE
use '==' for isNumeric to support strings and numbers

### DIFF
--- a/lib/cart.js
+++ b/lib/cart.js
@@ -1,5 +1,5 @@
 function isNumeric(val) {
-    return Number(parseFloat(val)).toString() === val;
+    return Number(parseFloat(val)).toString() == val;
 }
 
 module.exports = function (restClient) {


### PR DESCRIPTION
Closes #27 
When passing a Cart ID that is type of number this function returns false currently. `isNumeric` only returns `true` if it's a `string` with a number value. It should return true if it's a `number` also.