### PR TITLE
Add Custom headers to magento rest api calls

### DIFF
--- a/lib/cart.js
+++ b/lib/cart.js
@@ -142,18 +142,18 @@ module.exports = function (restClient) {
         }
     }       
 
-    module.paymentInformationAndOrder = function (customerToken, cartId, body, adminRequest = false) {
+    module.paymentInformationAndOrder = function (customerToken, cartId, body, adminRequest = false, headers = {}) {
         if (adminRequest) {
-            return restClient.post('/carts/' + cartId + '/payment-information', body);
+            return restClient.post('/carts/' + cartId + '/payment-information', body, '', headers);
         } else {
             if (customerToken && isNumeric(cartId)) {
-                return restClient.post('/carts/mine/payment-information', body, customerToken);
-            } else 
+                return restClient.post('/carts/mine/payment-information', body, customerToken, headers);
+            } else
             {
-                return restClient.post('/guest-carts/' + cartId + '/payment-information', body);
+                return restClient.post('/guest-carts/' + cartId + '/payment-information', body, '', headers);
             }
         }
-    }       
+    }      
 
     module.assign = function (cartId, userId, storeId = 0) {
         return restClient.put('/guest-carts/' + cartId, 

--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -24,13 +24,19 @@ module.exports.RestClient = function (options) {
         secret: options.accessTokenSecret
     };
 
-    function apiCall(request_data, request_token = '') {
+    function apiCall(request_data, request_token = '', customHeaders = {}) {
         /* eslint no-undef: off*/        
         return new Promise(function (resolve, reject) {
             request({
                 url: request_data.url,
                 method: request_data.method,
-                headers: request_token ? { 'Authorization': 'Bearer ' + request_token } : oauth.toHeader(oauth.authorize(request_data, token)),
+                headers: {
+                    ...(request_token 
+                        ? { 'Authorization': 'Bearer ' + request_token }
+                        : oauth.toHeader(oauth.authorize(request_data, token))
+                    ),
+                    ...customHeaders
+                },
                 json: true,
                 body: request_data.body,
             }, function (error, response, body) {
@@ -102,13 +108,13 @@ module.exports.RestClient = function (options) {
         return servelrUrl + '/' + apiVersion + resourceUrl;
     }
 
-    instance.post = function (resourceUrl, data, request_token = '') {
+    instance.post = function (resourceUrl, data, request_token = '', customHeaders = {}) {
         var request_data = {
             url: createUrl(resourceUrl),
             method: 'POST',
             body: data
         };
-        return apiCall(request_data, request_token);
+        return apiCall(request_data, request_token, customHeaders);
     }
 
     instance.put = function (resourceUrl, data, request_token = '') {


### PR DESCRIPTION
We have found cases in which we need to send custom http headers from vsf-api to magento rest-api

In our case we needed to send the user-agent to the `paymentInformationAndOrder` endpoint
This is needed for integration of Vue Storefront with the Adyen Payment Method, as Adyen requires the user's userAgent to be send to the `paymentInformationAndOrder` method

In this pull request we have added:
- `customHeaders` parameter to the client's apiCall method which enables adding custom headers to any call to magento's rest api from vsf-api
- Passing this customHeaders to the paymentInformationAndOrder endpoint method

We know this may be quite specific to our use case but it is 100% needed for Adyen integration, which is quite extended  payment method used by lots of merchants.

We are planning on making our Vue Storefront-Adyen integration public and we are trying to make it as easy as possible to install by reducing the number of forked repos which are needed.
We are close to have all needed changes to official Magento Adyen Extension repository merged so we can remove that fork:
- https://github.com/Adyen/adyen-magento2/pull/786
- https://github.com/Adyen/adyen-magento2/issues/787

It would be great to see changes added to this repo merged so it does not need to be forked either.

