### PR TITLE
Fix the Issue : After Magento 2.4.4 upgrade, Error : Signature method HMAC-SHA1 is not supported #39

### DIFF
--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -17,7 +17,7 @@ module.exports.RestClient = function (options) {
             public: options.consumerKey,
             secret: options.consumerSecret
         },
-        signature_method: 'HMAC-SHA1'
+        signature_method: options.signatureMethod
     });
     var token = {
         public: options.accessToken,

--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -17,7 +17,7 @@ module.exports.RestClient = function (options) {
             public: options.consumerKey,
             secret: options.consumerSecret
         },
-        signature_method: options.signatureMethod
+        signature_method: options.signatureMethod || 'HMAC-SHA1'
     });
     var token = {
         public: options.accessToken,


### PR DESCRIPTION
Fix for the issue : [https://github.com/vuestorefront/magento2-rest-client/issues/39](https://github.com/vuestorefront/magento2-rest-client/issues/39)

Use config option to set signatureMethod
--------------------Example----------------
```
    var Magento2Client = require('magento2-rest-client').Magento2Client;
    var options = {
          'url': 'http://www.test.com/index.php/rest',
          'consumerKey': '<OAuth 1.0a consumer key>',
          'consumerSecret': '<OAuth 1.0a consumer secret>',
          'accessToken': '<OAuth 1.0a access token>',
          'accessTokenSecret': '<OAuth 1.0a access token secret>',
          'signatureMethod':  'HMAC-SHA256',
    };
    var client = Magento2Client(options);
```